### PR TITLE
bugfix first row

### DIFF
--- a/scripts/ImportJSON/Code.gs
+++ b/scripts/ImportJSON/Code.gs
@@ -283,7 +283,7 @@ function parseData_(headers, data, path, state, value, query, options, includeFu
       if (parseData_(headers, data, path, state, value[i], query, options, includeFunc)) {
         dataInserted = true;
 
-        if (i > 0 && data[state.rowIndex]) {
+        if (i >= 0 && data[state.rowIndex]) {
           state.rowIndex++;
         }
       }


### PR DESCRIPTION
If response have more than one string script lose first string, because rewrite second string to first. I fixed it